### PR TITLE
Adapt for amazon linux 2 

### DIFF
--- a/tasks/conf.yml
+++ b/tasks/conf.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: gather EC2 facts
-  ec2_facts:
+  ec2_metadata_facts:
 
 - name: "Make /var/awslogs/state/ directory"
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,6 @@
     include: "conf.yml"
   when: ansible_os_family == "RedHat"    
 
-- name: Display all variables/facts known for a host
-  debug:
-    var: hostvars[inventory_hostname]
-  tags: debug_info
-
 - block:
   - name: "Download Debian/Ubuntu Cloudwatch Log Agent Install Script."
     include: "Debian.yml"
@@ -39,8 +34,8 @@
       state: restarted
       enabled: yes
   # If amazon linux 1 or not amazon linux 2
-  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "2") or
-        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "1")
+  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
+        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03")
 
 - block:
   - name: "Restart awslogsd service."
@@ -49,4 +44,4 @@
       state: restarted
       enabled: yes
   # If amazon linux 2
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version >= "2"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,11 @@
     name: awslogs
     state: restarted
     enabled: yes
+  when: ansible_distribution != "Amazon" and ansible_distribution_version != "2"
+
+- name: "Restart awslogsd service."
+  service:
+    name: awslogsd
+    state: restarted
+    enabled: yes
+  when: ansible_distribution == "Amazon" and ansible_distribution_version == "2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
 
-- name: "Install RedHat/AMZN Linux Cloudwatch Log Agent."
-  include: "RedHat.yml"
-  when: ansible_os_family == "RedHat"
+- block:
+  - name: "Install RedHat/AMZN Linux Cloudwatch Log Agent."
+    include: "RedHat.yml"
+
+  - name: "Configure Cloudwatch Log Agent."
+      include: "conf.yml"
+  when: ansible_os_family == "RedHat"    
 
 - block:
   - name: "Download Debian/Ubuntu Cloudwatch Log Agent Install Script."
@@ -38,11 +42,4 @@
       state: restarted
       enabled: yes
 
-  # - name: "Configure AWS CloudWatch Logs Agent - Region"
-  #   template:
-  #     src: etc/awslogs/awscli.conf.j2
-  #     dest: /etc/awslogs/awscli.conf
-  #     owner: root
-  #     group: root
-  #     mode: 0644
   when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,11 @@
     include: "conf.yml"
   when: ansible_os_family == "RedHat"    
 
+- name: Display all variables/facts known for a host
+  debug:
+    var: hostvars[inventory_hostname]
+  tags: debug_info
+
 - block:
   - name: "Download Debian/Ubuntu Cloudwatch Log Agent Install Script."
     include: "Debian.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,11 @@
       enabled: yes
   when: ansible_distribution != "Amazon" and ansible_distribution_major_version != "2"
 
+- name: Display all variables/facts known for a host
+  debug:
+    var: hostvars[inventory_hostname]
+    verbosity: 4
+    
 - block:
   - name: "Restart awslogsd service."
     service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and ansible_distribution_version != "2"
+  when: ansible_distribution != "Amazon" and ansible_distribution_major_version != "2"
 
 - block:
   - name: "Restart awslogsd service."
@@ -45,4 +45,4 @@
   #     owner: root
   #     group: root
   #     mode: 0644
-  when: ansible_distribution == "Amazon" and ansible_distribution_version == "2"
+  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     include: "RedHat.yml"
 
   - name: "Configure Cloudwatch Log Agent."
-      include: "conf.yml"
+    include: "conf.yml"
   when: ansible_os_family == "RedHat"    
 
 - block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,24 +15,34 @@
     include: "DebianInstall.yml"
   when: ansible_os_family == "Debian"
 
-- name: "Set region for Cloudwatch endpoint"
-  template:
-    src: templates/etc/aws.conf.j2
-    dest: /var/awslogs/etc/aws.conf
-    owner: root
-    group: root
-    mode: 0600
+- block:
+  - name: "Set region for Cloudwatch endpoint"
+    template:
+      src: templates/etc/aws.conf.j2
+      dest: /var/awslogs/etc/aws.conf
+      owner: root
+      group: root
+      mode: 0600
 
-- name: "Restart awslogs service."
-  service:
-    name: awslogs
-    state: restarted
-    enabled: yes
+  - name: "Restart awslogs service."
+    service:
+      name: awslogs
+      state: restarted
+      enabled: yes
   when: ansible_distribution != "Amazon" and ansible_distribution_version != "2"
 
-- name: "Restart awslogsd service."
-  service:
-    name: awslogsd
-    state: restarted
-    enabled: yes
+- block:
+  - name: "Restart awslogsd service."
+    service:
+      name: awslogsd
+      state: restarted
+      enabled: yes
+
+  # - name: "Configure AWS CloudWatch Logs Agent - Region"
+  #   template:
+  #     src: etc/awslogs/awscli.conf.j2
+  #     dest: /etc/awslogs/awscli.conf
+  #     owner: root
+  #     group: root
+  #     mode: 0644
   when: ansible_distribution == "Amazon" and ansible_distribution_version == "2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and ansible_distribution_major_version != "2"
+  when: ansible_distribution != "Amazon" and os_family != "Redhat"
 
 - name: Display all variables/facts known for a host
   debug:
@@ -47,4 +47,4 @@
       state: restarted
       enabled: yes
 
-  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "2"
+  when: ansible_distribution == "Amazon" and os_family == "Redhat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,4 +42,4 @@
       state: restarted
       enabled: yes
 
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_verion == "(Karoo)"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,12 +33,12 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and os_family != "Redhat"
+  when: ansible_distribution != "Amazon" and ansible_os_family != "Redhat"
 
-- name: Display all variables/facts known for a host
-  debug:
-    var: hostvars[inventory_hostname]
-  tags: debug_info
+# - name: Display all variables/facts known for a host
+#   debug:
+#     var: hostvars[inventory_hostname]
+#   tags: debug_info
 
 - block:
   - name: "Restart awslogsd service."
@@ -47,4 +47,4 @@
       state: restarted
       enabled: yes
 
-  when: ansible_distribution == "Amazon" and os_family == "Redhat"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "Redhat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and ansible_os_family != "Redhat"
+  when: ansible_distribution != "Amazon" and ansible_os_family != "RedHat"
 
 # - name: Display all variables/facts known for a host
 #   debug:
@@ -47,4 +47,4 @@
       state: restarted
       enabled: yes
 
-  when: ansible_distribution == "Amazon" and ansible_os_family == "Redhat"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,8 +34,8 @@
       state: restarted
       enabled: yes
   # If amazon linux 1 or not amazon linux 2
-  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
-        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03")
+  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "2") or
+        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "1")
 
 - block:
   - name: "Restart awslogsd service."
@@ -44,4 +44,4 @@
       state: restarted
       enabled: yes
   # If amazon linux 2
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version >= "2"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,8 +38,8 @@
 - name: Display all variables/facts known for a host
   debug:
     var: hostvars[inventory_hostname]
-    verbosity: 4
-    
+  tags: debug_info
+
 - block:
   - name: "Restart awslogsd service."
     service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,9 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)"
+  # If amazon linux 1 or not amazon linux 2
+  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
+        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03")
 
 - block:
   - name: "Restart awslogsd service."
@@ -41,5 +43,5 @@
       name: awslogsd
       state: restarted
       enabled: yes
-
+  # If amazon linux 2
   when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,12 +33,7 @@
       name: awslogs
       state: restarted
       enabled: yes
-  when: ansible_distribution != "Amazon" and ansible_os_family != "RedHat"
-
-# - name: Display all variables/facts known for a host
-#   debug:
-#     var: hostvars[inventory_hostname]
-#   tags: debug_info
+  when: ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)"
 
 - block:
   - name: "Restart awslogsd service."
@@ -47,4 +42,4 @@
       state: restarted
       enabled: yes
 
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat"
+  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_verion == "(Karoo)"


### PR DESCRIPTION
According to [AWS cloudwatch agent setup instructions](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html), if using Linux 2, the service name must be referenced as `awslogsd` rather than `awslogs`. 

`ec2_facts` has been deprecated and replaced with `ec2_metadata_facts`