### PR TITLE
Updating ec2_facts to ec2_metadata_facts (deprecated in Ansible 2.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs AWS CloudWatch Log Agent
 Requirements
 ------------
 
-Requires ec2_facts.
+Requires ec2_metadata_facts.
 
 Role Variables
 --------------

--- a/tasks/DebianInstall.yml
+++ b/tasks/DebianInstall.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: "Get ec2 facts (Debian)."
-  action: ec2_facts
+  action: ec2_metadata_facts
 
 - name: "Update Package Lists (Debian)."
   apt:

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -9,7 +9,7 @@
 
 - block:
   - name: "Get ec2 facts (RedHat)."
-    action: ec2_facts
+    action: ec2_metadata_facts
 
   - name: "Download Install Script (RedHat)."
     get_url:


### PR DESCRIPTION
So, the ec2_facts action in Ansible was deprecated a while ago. I think this should be a drop-in replacement; a similar module made this change a while ago. Without this, Ansible barfs because this isn't valid anymore.