### PR TITLE
Adding code to support RHEL7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
       state: restarted
       enabled: yes
   # If not Amazon Linux 2
-  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)")
+  when: not (ansible_distribution == "Amazon" and ansible_distribution_version == "(Karoo)")
 
 - block:
   - name: "Restart awslogsd service."
@@ -42,5 +42,5 @@
       name: awslogsd
       state: restarted
       enabled: yes
-  # If amazon linux 2
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"
+  # If Amazon Linux 2
+  when: ansible_distribution == "Amazon" and ansible_distribution_version == "(Karoo)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,8 @@
       enabled: yes
   # If amazon linux 1 or not amazon linux 2
   when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
-        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03")
+        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03") or
+        (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7")
 
 - block:
   - name: "Restart awslogsd service."

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,10 +33,8 @@
       name: awslogs
       state: restarted
       enabled: yes
-  # If amazon linux 1 or not amazon linux 2
-  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
-        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03") or
-        (ansible_distribution == "RedHat" and ansible_distribution_major_version == "7")
+  # If not Amazon Linux 2
+  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)")
 
 - block:
   - name: "Restart awslogsd service."


### PR DESCRIPTION
This adds another conditional for RHEL7. This is a JANKY ASS WAY OF DOING THIS. I think what we really want to do is have a variable set {{ awslogs_daemon }} which is what I did in the application-specific module, and then change that based on distro, but I have spent an hour trying to figure out the "best practice" way of doing that and I can't find the "right" way of doing it yet, so I am just going to push this and we can fix that later. This is good enough for two distros, but if we start supporting Ubuntu too, we'll need to fix this.