### PR TITLE
TAWCS-113 Update AL2 version check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Check ansible version
+  fail:
+      msg: You must use ansible 2.8 or greater
+  when: not ansible_version.full is version("2.8", ">=")
+
 - block:
   - name: "Install RedHat/AMZN Linux Cloudwatch Log Agent."
     include: "RedHat.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
       state: restarted
       enabled: yes
   # If not Amazon Linux 2
-  when: not (ansible_distribution == 'Amazon' and ansible_distribution_major_version is version('2', '=='))
+  when: not (ansible_distribution == "Amazon" and ansible_distribution_major_version is version("2", "=="))
 
 - block:
   - name: "Restart awslogsd service."
@@ -43,4 +43,4 @@
       state: restarted
       enabled: yes
   # If amazon linux 2
-  when: ansible_distribution == 'Amazon' and ansible_distribution_major_version is version('2', '==')
+  when: ansible_distribution == "Amazon" and ansible_distribution_major_version is version("2", "==")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,8 @@
       name: awslogs
       state: restarted
       enabled: yes
-  # If amazon linux 1 or not amazon linux 2
-  when: (ansible_distribution != "Amazon" and ansible_os_family != "RedHat" and ansible_distribution_version != "(Karoo)") or
-        (ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "2018.03")
+  # If not Amazon Linux 2
+  when: not (ansible_distribution == 'Amazon' and ansible_distribution_major_version is version('2', '=='))
 
 - block:
   - name: "Restart awslogsd service."
@@ -44,4 +43,4 @@
       state: restarted
       enabled: yes
   # If amazon linux 2
-  when: ansible_distribution == "Amazon" and ansible_os_family == "RedHat" and ansible_distribution_version == "(Karoo)"
+  when: ansible_distribution == 'Amazon' and ansible_distribution_major_version is version('2', '==')


### PR DESCRIPTION
Per https://jiraent.cms.gov/browse/TAWCS-113, incorporate the Ansible 2.8 fix for checking the AL2 version. The change has been tested in the gold image repo: the Cloudwatch agent is still successfully installed and enabled in the AL 2 and RHEL 7 AMIs.